### PR TITLE
Webapi Fix Heap Size

### DIFF
--- a/app-specs/ohdsi/docker-compose.yaml
+++ b/app-specs/ohdsi/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
       resources:
         limits:
           cpus: '1'
-          memory: 10000M
+          memory: 12G
         reservations:
           cpus: '1'
-          memory: 10000M
+          memory: 12G

--- a/app-specs/ohdsi/docker-compose.yaml
+++ b/app-specs/ohdsi/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
       - FLYWAY_SCHEMAS=webapi
       - FLYWAY_PLACEHOLDERS_OHDSISCHEMA=webapi
       - SECURITY_PROVIDER=DisabledSecurity
-      - JAVA_OPTS="-Xmx8g
+      - JAVA_OPTS=-Xmx8g
     image: ohdsi/webapi:latest
     deploy:
       resources:

--- a/app-specs/ohdsi/docker-compose.yaml
+++ b/app-specs/ohdsi/docker-compose.yaml
@@ -23,13 +23,13 @@ services:
       - FLYWAY_SCHEMAS=webapi
       - FLYWAY_PLACEHOLDERS_OHDSISCHEMA=webapi
       - SECURITY_PROVIDER=DisabledSecurity
-      - JAVA_OPTS=-Xmx8g
+      - JAVA_OPTS=-Xmx6g
     image: ohdsi/webapi:latest
     deploy:
       resources:
         limits:
           cpus: '1'
-          memory: 12G
+          memory: 9G
         reservations:
           cpus: '1'
-          memory: 12G
+          memory: 9G

--- a/app-specs/ohdsi/docker-compose.yaml
+++ b/app-specs/ohdsi/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
       resources:
         limits:
           cpus: '1'
-          memory: 6000M
+          memory: 10000M
         reservations:
           cpus: '1'
-          memory: 6000M
+          memory: 10000M

--- a/app-specs/ohdsi/docker-compose.yaml
+++ b/app-specs/ohdsi/docker-compose.yaml
@@ -23,13 +23,13 @@ services:
       - FLYWAY_SCHEMAS=webapi
       - FLYWAY_PLACEHOLDERS_OHDSISCHEMA=webapi
       - SECURITY_PROVIDER=DisabledSecurity
-      - JAVA_OPTS=-Xmx6g
+      - JAVA_OPTS=-Xmx5g
     image: ohdsi/webapi:latest
     deploy:
       resources:
         limits:
           cpus: '1'
-          memory: 9G
+          memory: 8G
         reservations:
           cpus: '1'
-          memory: 9G
+          memory: 8G

--- a/app-specs/ohdsi/docker-compose.yaml
+++ b/app-specs/ohdsi/docker-compose.yaml
@@ -23,13 +23,13 @@ services:
       - FLYWAY_SCHEMAS=webapi
       - FLYWAY_PLACEHOLDERS_OHDSISCHEMA=webapi
       - SECURITY_PROVIDER=DisabledSecurity
-      - JAVA_OPTS=-Xmx5g
+      - JAVA_OPTS=-Xmx6g
     image: ohdsi/webapi:latest
     deploy:
       resources:
         limits:
           cpus: '1'
-          memory: 8G
+          memory: 9G
         reservations:
           cpus: '1'
-          memory: 8G
+          memory: 9G

--- a/app-specs/ohdsi/docker-compose.yaml
+++ b/app-specs/ohdsi/docker-compose.yaml
@@ -23,6 +23,7 @@ services:
       - FLYWAY_SCHEMAS=webapi
       - FLYWAY_PLACEHOLDERS_OHDSISCHEMA=webapi
       - SECURITY_PROVIDER=DisabledSecurity
+      - JAVA_OPTS="-Xmx8g
     image: ohdsi/webapi:latest
     deploy:
       resources:

--- a/app-specs/ohdsi/docker-compose.yaml
+++ b/app-specs/ohdsi/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
       resources:
         limits:
           cpus: '1'
-          memory: 3000M
+          memory: 6000M
         reservations:
           cpus: '1'
-          memory: 3000M
+          memory: 6000M


### PR DESCRIPTION
After some experimentation, the minimum size heap is 6G, and 3G more for general processing (9G total).  Had to increase resources but also explicitly set heap size using `-Xmx` option