### PR TITLE
Alter atlas-webapi memory usage

### DIFF
--- a/app-specs/atlas/docker-compose.yaml
+++ b/app-specs/atlas/docker-compose.yaml
@@ -23,12 +23,13 @@ services:
       - FLYWAY_SCHEMAS=webapi
       - FLYWAY_PLACEHOLDERS_OHDSISCHEMA=webapi
       - SECURITY_PROVIDER=DisabledSecurity
+      - JAVA_OPTS=-Xmx6g
     image: containers.renci.org/helxplatform/ohdsi-webapi:0.2.0
     deploy:
       resources:
         limits:
           cpus: '1'
-          memory: 2000M
+          memory: 9G
         reservations:
           cpus: '1'
-          memory: 2000M
+          memory: 9G


### PR DESCRIPTION
webapi uses a lot of memory in particular the heap needs a minimum of 6G; this may be due in part to the database size, but whatever the reason, if set too low then there is inevitable heap exhaustion during startup.  

This fixes that problem by allocating 9G of memory while setting aside 6G for heap space by using the java -Xmx flag