### PR TITLE
Return to unaltered webapi image

### DIFF
--- a/app-specs/atlas/docker-compose.yaml
+++ b/app-specs/atlas/docker-compose.yaml
@@ -24,6 +24,7 @@ services:
       - FLYWAY_PLACEHOLDERS_OHDSISCHEMA=webapi
       - SECURITY_PROVIDER=DisabledSecurity
       - JAVA_OPTS=-Xmx6g
+      - xxx={{ username }}
     image: ohdsi/webapi:latest
     deploy:
       resources:

--- a/app-specs/atlas/docker-compose.yaml
+++ b/app-specs/atlas/docker-compose.yaml
@@ -24,7 +24,6 @@ services:
       - FLYWAY_PLACEHOLDERS_OHDSISCHEMA=webapi
       - SECURITY_PROVIDER=DisabledSecurity
       - JAVA_OPTS=-Xmx6g
-      - xxx={{ '{{ username }}' }}
     image: ohdsi/webapi:latest
     deploy:
       resources:

--- a/app-specs/atlas/docker-compose.yaml
+++ b/app-specs/atlas/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       - FLYWAY_PLACEHOLDERS_OHDSISCHEMA=webapi
       - SECURITY_PROVIDER=DisabledSecurity
       - JAVA_OPTS=-Xmx6g
-    image: containers.renci.org/helxplatform/ohdsi-webapi:0.2.0
+    image: ohdsi/webapi:latest
     deploy:
       resources:
         limits:

--- a/app-specs/atlas/docker-compose.yaml
+++ b/app-specs/atlas/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       - FLYWAY_PLACEHOLDERS_OHDSISCHEMA=webapi
       - SECURITY_PROVIDER=DisabledSecurity
       - JAVA_OPTS=-Xmx6g
-      - xxx={{ username }}
+      - xxx={{ '{{ username }}' }}
     image: ohdsi/webapi:latest
     deploy:
       resources:


### PR DESCRIPTION
A new feature of tycho allows for variable database connection strings constructed from the username.  That allows us to return to the canonical `webapi` image, thus avoiding a webapi initialization error and stack trace.