### PR TITLE
Add helx_user to allow subsitition of username in docker-compose

### DIFF
--- a/app-registry.yaml
+++ b/app-registry.yaml
@@ -60,6 +60,7 @@ repositories:
 settings:
   helx_registry: containers.renci.org
   third_party_registry: docker.io
+  helx_user: "{{ username }}"
 contexts:
   # The common context provides a convenient base set of applications.
   # Other contexts can extend it to include these apps.


### PR DESCRIPTION
This small trick enables the use of `{{ username }}` in docker-compose.  A useful feature if you want to refer to a user's home directory.  

This works because template substitution in tycho happens twice.  First when converting docker-compose app specs and later when converting those intermediate forms to pod specs.  It turns out **username** is defined only during the 2nd phase, not the first, so `{{ helx_user }}` merely transforms to `{{ username }}` during phase1, and then later to the actual username during phase2.